### PR TITLE
Changed the click function of the create button operation.

### DIFF
--- a/summernote-ext-elfinder.js
+++ b/summernote-ext-elfinder.js
@@ -30,10 +30,11 @@
         // create button
         var button = ui.button({
           contents: '<i class="fa fa-list-alt"/> File Manager',
-          tooltip: 'elfinder',
+          //tooltip: 'elfinder',
           click: function () {
-              elfinderDialog($(this).closest('.note-editor').parent().children('.summernote'));
-          }
+	            	elfinderDialog($(this).closest('.note-editor').prev('[data-editor="summernote"]'));
+        		}
+          });
         });
         
         // create jQuery object from button instance.


### PR DESCRIPTION
I'm using Bootstrap v4.1.3 with Summernote-BS4 v0.8.10, jQuery v3.3.1, jQuery UI - v1.12.1

Previous code required the class .summernote and if there were multiple editors would always add to the first editor. This code goes to the top of the editor in the DOM and targets the preceding element with the data-editor attribute of "summernote" which will be the correct target even if there are multiple editors.